### PR TITLE
Fix WhatsApp message encoding

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,11 +71,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        // Construct WhatsApp message
-        const whatsappMessage = `Hello Harsh,%0A%0AName: ${encodeURIComponent(name)}%0AEmail: ${encodeURIComponent(email)}%0AMessage: ${encodeURIComponent(message)}`;
+        // Construct WhatsApp message and encode it once
+        const rawMessage = `Hello Harsh,\n\nName: ${name}\nEmail: ${email}\nMessage: ${message}`;
 
         // WhatsApp API URL
-        const whatsappURL = `https://wa.me/919574288197?text=${whatsappMessage}`;
+        const whatsappURL = `https://wa.me/919574288197?text=${encodeURIComponent(rawMessage)}`;
 
         // Redirect to WhatsApp
         window.open(whatsappURL, '_blank');


### PR DESCRIPTION
## Summary
- fix the WhatsApp redirect URL so the entire message is encoded once

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872003b08788327814d78775ed1df3c